### PR TITLE
Fix 'TypeError: must be type, not classobj'

### DIFF
--- a/yaff/scene.py
+++ b/yaff/scene.py
@@ -1,4 +1,4 @@
-class Scene:
+class Scene(object):
 
     def __init__(self, parent=None):
 


### PR DESCRIPTION
The class Scene must have as parent the class 'object' otherwise Python returns the error 'TypeError: must be type, not classobj' when a  derived class (such as SplashScreen) call 'super()'.
